### PR TITLE
Removes full path from npm script example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@ Cleans your React Native project by purging caches and modules, and reinstalling
 
 # Tip
 Add to package.json
-`
+
+```js
 "scripts": {
-	...
-    "purge": "./node_modules/.bin/react-native-clean-project",
-	...
-  },
-  `
+  ...
+  "purge": "react-native-clean-project",
+  ...
+},
+```
 
 # 
 


### PR DESCRIPTION
If you have defined a `bin` entry in the package.json, you don't need to prefix it with `./node_modules/.bin`. npm will look it up for you.