### PR TITLE
fix: wipe iOS build should wipe all iOS build artifacts, Fixes #18

### DIFF
--- a/source/internals/tasks.js
+++ b/source/internals/tasks.js
@@ -4,9 +4,10 @@
 
 const tasks = {
   wipeiOSBuildFolder: {
-    name: 'wipe iOS build folder',
-    command: 'rm',
-    args: ['-rf', 'ios/build']
+    name: 'wipe iOS build artifacts',
+    command:
+      'rm -rf ios/build && (killall Xcode || true) && xcrun -k && cd ios && xcodebuild -alltargets clean && cd .. && rm -rf "$(getconf DARWIN_USER_CACHE_DIR)/org.llvm.clang/ModuleCache" && rm -rf "$(getconf DARWIN_USER_CACHE_DIR)/org.llvm.clang.$(whoami)/ModuleCache" && rm -fr ~/Library/Developer/Xcode/DerivedData/ && rm -fr ~/Library/Caches/com.apple.dt.Xcode/',
+    args: []
   },
   wipeiOSPodsFolder: {
     name: 'wipe iOS Pods folder',


### PR DESCRIPTION
This string interprets the commands I posted on #18 and tests out on my build

It fixes the problem I had upgrading react-native-firebase 5.4.x to 5.5.x where some entire files were deleted but xcodebuild couldn't figure it out