### PR TITLE
fix askiOSPods command-line behavior

### DIFF
--- a/source/internals/options.js
+++ b/source/internals/options.js
@@ -67,7 +67,7 @@ const askiOS = () =>
 const askiOSPods = () =>
   new Promise(resolve => {
     if (args.includes('--remove-iOS-pods')) {
-      wipeiOSBuild = true;
+      wipeiOSPods = true;
       return resolve();
     }
     return askQuestion('Wipe iOS Pods folder? (Y/n) ', answer => {


### PR DESCRIPTION
Hello @pmadruga  :-)

I discovered an error in a feature I think I PRd here earlier (if so, sorry!)

askiOSPods, when requested by non-interactive flag, was accidentally
mapped to the wipeiOSBuilds boolean instead of wipeiOSPods

This PR sets the correct flag