### PR TITLE
fix: remove npm ci from autoTasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This is a combination of the commands suggested in the React Native documentatio
 | Yarn cache           | `yarn cache clean`            | Yes                      | Yes        | true     | --keep-node-modules    |
 | Yarn packages        | `yarn install`                | No                       | Yes        | true     | --keep-node-modules    |
 | NPM cache            | `npm cache verify`            | Yes                      | Yes        | true     | --keep-node-modules    |
-| NPM Install          | `npm ci`                      | Yes                      | Yes        | true     | --keep-node-modules    |
+| NPM Install          | `npm ci`                      | No                       | Yes        | true     | --keep-node-modules    |
 | iOS build folder     | `rm -rf ios/build`            | Yes                      | Yes        | false    | --remove-iOS-build     |
 | iOS pods folder      | `rm -rf ios/pods`             | Yes                      | Yes        | false    | --remove-iOS-pods      |
 | Android build folder | `rm -rf android/build`        | Yes                      | Yes        | false    | --remove-android-build |

--- a/source/internals/tasks.js
+++ b/source/internals/tasks.js
@@ -79,8 +79,7 @@ const autoTasks = [
   tasks.wipeTempCaches,
   tasks.wipeNodeModules,
   tasks.yarnCacheClean,
-  tasks.npmCacheVerify,
-  tasks.npmInstall
+  tasks.npmCacheVerify
 ];
 
 module.exports = {

--- a/test/tasks.test.js
+++ b/test/tasks.test.js
@@ -24,7 +24,7 @@ describe('Correct auto tasks run', () => {
   it('should run the correct tasks in plugin auto-clean mode', () => {
     // auto-mode is the first plugin function, execute it
     plugin[0].func();
-    expect(tasksExecuted.length).toEqual(9);
+    expect(tasksExecuted.length).toEqual(8);
     autoTasks.forEach(task => {
       expect(tasksExecuted.includes(task.name)).toEqual(true);
     });


### PR DESCRIPTION
I believe we should not install automatically on autoTasks and leave it at user discretion to `npm ci` or `yarn install` after clean. 