### PR TITLE
Fix incorrect Pods Cache function naming

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -6,8 +6,8 @@ const { tasks } = require('./internals/tasks');
 options
   .askiOS()
   .then(options.askiOSPods)
-  .then(options.askSystemPodsCache)
-  .then(options.askUserPodsCache)
+  .then(options.askSystemiOSPodsCache)
+  .then(options.askUseriOSPodsCache)
   .then(options.askUpdatePods)
   .then(options.askAndroid)
   .then(options.askAndroidCleanProject)
@@ -21,11 +21,11 @@ options
     if (options.getWipeiOSPods()) {
       executeTask(tasks.wipeiOSPodsFolder);
     }
-    if (options.getWipeSystemPodsCache()) {
-      executeTask(tasks.wipeSystemPodsCache);
+    if (options.getWipeSystemiOSPodsCache()) {
+      executeTask(tasks.wipeSystemiOSPodsCache);
     }
-    if (options.getWipeUserPodsCache()) {
-      executeTask(tasks.wipeUserPodsCache);
+    if (options.getWipeUseriOSPodsCache()) {
+      executeTask(tasks.wipeUseriOSPodsCache);
     }
     if (options.getWipeAndroidBuild()) {
       executeTask(tasks.wipeAndroidBuildFolder);


### PR DESCRIPTION
I missed these when renaming the functions earlier for #51