### PR TITLE
Fix incorrect system cache pod clear command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,24 +37,24 @@ Or add it as a script to your `package.json`
 
 This is a combination of the commands suggested in the React Native documentation plus others.
 
-| State Type                | Command                           | In `clean-project-auto`? | Optional? | Default? | Option Flag                    |
-| ------------------------- | --------------------------------- | ------------------------ | --------- | -------- | ------------------------------ |
-| React-native cache        | `rm -rf $TMPDIR/react-*`          | Yes                      | No        | true     |                                |
-| Metro bundler cache       | `rm -rf $TMPDIR/metro-*`          | Yes                      | No        | true     |                                |
-| Watchman cache            | `watchman watch-del-all`          | Yes                      | No        | true     |                                |
-| NPM modules               | `rm -rf node_modules`             | Yes                      | Yes       | true     | --keep-node_modules            |
-| Yarn cache                | `yarn cache clean`                | Yes                      | Yes       | true     | --keep-node-modules            |
-| Yarn packages             | `yarn install`                    | No                       | Yes       | true     | --keep-node-modules            |
-| NPM cache                 | `npm cache verify`                | Yes                      | Yes       | true     | --keep-node-modules            |
-| NPM Install               | `npm ci`                          | Yes                      | Yes       | true     | --keep-node-modules            |
-| iOS build folder          | `rm -rf ios/build`                | Yes                      | Yes       | false    | --remove-iOS-build             |
-| iOS pods folder           | `rm -rf ios/Pods`                 | Yes                      | Yes       | false    | --remove-iOS-pods              |
-| system iOS pods cache     | `pod cache clear --all`           | Yes                      | Yes       | false    | --remove-system-iOS-pods-cache |
-| user iOS pods cache       | `rm -rf ~/.cocoapods`             | Yes                      | Yes       | false    | --remove-user-iOS-pods-cache   |
-| Android build folder      | `rm -rf android/build`            | Yes                      | Yes       | false    | --remove-android-build         |
-| Android clean project     | `(cd android && ./gradlew clean)` | Yes                      | Yes       | false    | --clean-android-project        |
-| Brew package              | `brew update && brew upgrade`     | No                       | Yes       | true     | --keep-brew                    |
-| Pod packages              | `pod update`                      | No                       | Yes       | true     | --keep-pods                    |
+| State Type                | Command                           | In `clean-project-auto`? | Optional? | Default? | Option Flag                  |
+| ------------------------- | --------------------------------- | ------------------------ | --------- | -------- | ---------------------------- |
+| React-native cache        | `rm -rf $TMPDIR/react-*`          | Yes                      | No        | true     |                              |
+| Metro bundler cache       | `rm -rf $TMPDIR/metro-*`          | Yes                      | No        | true     |                              |
+| Watchman cache            | `watchman watch-del-all`          | Yes                      | No        | true     |                              |
+| NPM modules               | `rm -rf node_modules`             | Yes                      | Yes       | true     | --keep-node_modules          |
+| Yarn cache                | `yarn cache clean`                | Yes                      | Yes       | true     | --keep-node-modules          |
+| Yarn packages             | `yarn install`                    | No                       | Yes       | true     | --keep-node-modules          |
+| NPM cache                 | `npm cache verify`                | Yes                      | Yes       | true     | --keep-node-modules          |
+| NPM Install               | `npm ci`                          | Yes                      | Yes       | true     | --keep-node-modules          |
+| iOS build folder          | `rm -rf ios/build`                | Yes                      | Yes       | false    | --remove-iOS-build           |
+| iOS pods folder           | `rm -rf ios/Pods`                 | Yes                      | Yes       | false    | --remove-iOS-pods            |
+| system iOS pods cache     | `pod cache clear --all`           | Yes                      | Yes       | true     | --keep-system-iOS-pods-cache |
+| user iOS pods cache       | `rm -rf ~/.cocoapods`             | Yes                      | Yes       | true     | --keep-user-iOS-pods-cache   |
+| Android build folder      | `rm -rf android/build`            | Yes                      | Yes       | false    | --remove-android-build       |
+| Android clean project     | `(cd android && ./gradlew clean)` | Yes                      | Yes       | false    | --clean-android-project      |
+| Brew package              | `brew update && brew upgrade`     | No                       | Yes       | true     | --keep-brew                  |
+| Pod packages              | `pod update`                      | No                       | Yes       | true     | --keep-pods                  |
 
 Example: `./node_modules/.bin/react-native-clean-project --remove-iOS-build`
 

--- a/source/internals/options.js
+++ b/source/internals/options.js
@@ -90,8 +90,8 @@ const askiOSPods = () =>
 
 const askSystemiOSPodsCache = () =>
   new Promise(resolve => {
-    if (args.includes('--remove-system-iOS-pods-cache')) {
-      wipeSystemiOSPodsCache = true;
+    if (args.includes('--keep-system-iOS-pods-cache')) {
+      wipeSystemiOSPodsCache = false;
       return resolve();
     }
     return askQuestion('Wipe system iOS Pods cache? (Y/n) ', answer => {
@@ -105,8 +105,8 @@ const askSystemiOSPodsCache = () =>
 
 const askUseriOSPodsCache = () =>
   new Promise(resolve => {
-    if (args.includes('--remove-user-iOS-pods-cache')) {
-      wipeUseriOSPodsCache = true;
+    if (args.includes('--keep-user-iOS-pods-cache')) {
+      wipeUseriOSPodsCache = false;
       return resolve();
     }
     return askQuestion('Wipe user iOS Pods cache? (Y/n) ', answer => {

--- a/source/internals/tasks.js
+++ b/source/internals/tasks.js
@@ -17,7 +17,7 @@ const tasks = {
   wipeSystemiOSPodsCache: {
     name: 'wipe system iOS Pods cache',
     command: 'pod',
-    args: ['cache', 'clear', '--all']
+    args: ['cache', 'clean', '--all']
   },
   wipeUseriOSPodsCache: {
     name: 'wipe user iOS Pods cache',


### PR DESCRIPTION
with sincere apologies @pmadruga  for the lack of quality in my original PR, this is a lesson in "even when it looks trivial you really need to test it...", there was one more issue in the original PR

I swear it works now! (I actually used the `dev-init` / `dev-sync` tasks to prove it to myself this time)

Should be `pod cache clean --all` not `pod cache clear --all`

Related to #51

One thing worth mentioning is that `executeTask()` can reject, but in all the calls to it except the one for the brew update / brew upgrade pair, the possible rejection is not handled with a `.catch()` on `executeTask` - I think that will fast-fail the script in the future but for now node is just really noisy about how rejections should be handled

That's a bigger change though, maybe an `executeTaskSimple` wrapper that relies on the underlying success/fail reporting and assumes the caller never wants a rejection so eats them all, then call that most of the time?