### PR TITLE
fix: Adds Android clean project task to auto task list as per readme doc

### DIFF
--- a/source/internals/tasks.js
+++ b/source/internals/tasks.js
@@ -91,6 +91,7 @@ const autoTasks = [
   tasks.wipeiOSPodsFolder,
   tasks.wipeSystemiOSPodsCache,
   tasks.wipeUseriOSPodsCache,
+  teask.cleanAndroidProject,
   tasks.wipeAndroidBuildFolder,
   tasks.watchmanCacheClear,
   tasks.wipeTempCaches,


### PR DESCRIPTION
The readme says that this task is part of the auto script however it wasn't getting run.