### PR TITLE
Fix typo in source/internals/tasks.js

### DIFF
--- a/source/internals/tasks.js
+++ b/source/internals/tasks.js
@@ -91,7 +91,7 @@ const autoTasks = [
   tasks.wipeiOSPodsFolder,
   tasks.wipeSystemiOSPodsCache,
   tasks.wipeUseriOSPodsCache,
-  teask.cleanAndroidProject,
+  tasks.cleanAndroidProject,
   tasks.wipeAndroidBuildFolder,
   tasks.watchmanCacheClear,
   tasks.wipeTempCaches,


### PR DESCRIPTION
Fix (source/internals/tasks.js): change `teask` to `tasks`

fixed a typo at line 94. Rename `teask` to `tasks`. Throws the following error while running without the fix.

```
error teask is not defined.
ReferenceError: teask is not defined
```