### PR TITLE
add wipe system gradle cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,24 +37,25 @@ Or add it as a script to your `package.json`
 
 This is a combination of the commands suggested in the React Native documentation plus others.
 
-| State Type                | Command                           | In `clean-project-auto`? | Optional? | Default? | Option Flag                  |
-| ------------------------- | --------------------------------- | ------------------------ | --------- | -------- | ---------------------------- |
-| React-native cache        | `rm -rf $TMPDIR/react-*`          | Yes                      | No        | true     |                              |
-| Metro bundler cache       | `rm -rf $TMPDIR/metro-*`          | Yes                      | No        | true     |                              |
-| Watchman cache            | `watchman watch-del-all`          | Yes                      | No        | true     |                              |
-| NPM modules               | `rm -rf node_modules`             | Yes                      | Yes       | true     | --keep-node-modules          |
-| Yarn cache                | `yarn cache clean`                | Yes                      | Yes       | true     | --keep-node-modules          |
-| Yarn packages             | `yarn install`                    | No                       | Yes       | true     | --keep-node-modules          |
-| NPM cache                 | `npm cache verify`                | Yes                      | Yes       | true     | --keep-node-modules          |
-| NPM Install               | `npm ci`                          | Yes                      | Yes       | true     | --keep-node-modules          |
-| iOS build folder          | `rm -rf ios/build`                | Yes                      | Yes       | false    | --remove-iOS-build           |
-| iOS pods folder           | `rm -rf ios/Pods`                 | Yes                      | Yes       | false    | --remove-iOS-pods            |
-| system iOS pods cache     | `pod cache clean --all`           | Yes                      | Yes       | true     | --keep-system-iOS-pods-cache |
-| user iOS pods cache       | `rm -rf ~/.cocoapods`             | Yes                      | Yes       | true     | --keep-user-iOS-pods-cache   |
-| Android build folder      | `rm -rf android/build`            | Yes                      | Yes       | false    | --remove-android-build       |
-| Android clean project     | `(cd android && ./gradlew clean)` | Yes                      | Yes       | false    | --clean-android-project      |
-| Brew package              | `brew update && brew upgrade`     | No                       | Yes       | true     | --keep-brew                  |
-| Pod packages              | `pod update`                      | No                       | Yes       | true     | --keep-pods                  |
+| State Type                  | Command                           | In `clean-project-auto`? | Optional? | Default? | Option Flag                  |
+| --------------------------- | --------------------------------- | ------------------------ | --------- | -------- | ---------------------------- |
+| React-native cache          | `rm -rf $TMPDIR/react-*`          | Yes                      | No        | true     |                              |
+| Metro bundler cache         | `rm -rf $TMPDIR/metro-*`          | Yes                      | No        | true     |                              |
+| Watchman cache              | `watchman watch-del-all`          | Yes                      | No        | true     |                              |
+| NPM modules                 | `rm -rf node_modules`             | Yes                      | Yes       | true     | --keep-node-modules          |
+| Yarn cache                  | `yarn cache clean`                | Yes                      | Yes       | true     | --keep-node-modules          |
+| Yarn packages               | `yarn install`                    | No                       | Yes       | true     | --keep-node-modules          |
+| NPM cache                   | `npm cache verify`                | Yes                      | Yes       | true     | --keep-node-modules          |
+| NPM Install                 | `npm ci`                          | Yes                      | Yes       | true     | --keep-node-modules          |
+| iOS build folder            | `rm -rf ios/build`                | Yes                      | Yes       | false    | --remove-iOS-build           |
+| iOS pods folder             | `rm -rf ios/Pods`                 | Yes                      | Yes       | false    | --remove-iOS-pods            |
+| system iOS pods cache       | `pod cache clean --all`           | Yes                      | Yes       | true     | --keep-system-iOS-pods-cache |
+| user iOS pods cache         | `rm -rf ~/.cocoapods`             | Yes                      | Yes       | true     | --keep-user-iOS-pods-cache   |
+| Android build folder        | `rm -rf android/build`            | Yes                      | Yes       | false    | --remove-android-build       |
+| Android clean project       | `(cd android && ./gradlew clean)` | Yes                      | Yes       | false    | --clean-android-project      |
+| Android system gradle cache | `rm -rf ~/.gradle/caches`         | Yes                      | Yes       | false    | --keep-system-gradle-cache   |
+| Brew package                | `brew update && brew upgrade`     | No                       | Yes       | true     | --keep-brew                  |
+| Pod packages                | `pod update`                      | No                       | Yes       | true     | --keep-pods                  |
 
 Example: `./node_modules/.bin/react-native-clean-project --remove-iOS-build`
 

--- a/source/internals/options.js
+++ b/source/internals/options.js
@@ -15,6 +15,7 @@ let wipeiOSPods = false;
 let wipeSystemiOSPodsCache = true;
 let wipeUseriOSPodsCache = true;
 let wipeAndroidBuild = false;
+let wipeSystemGradleCache = false;
 let wipeNodeModules = true;
 let updateBrew = true;
 let updatePods = true;
@@ -36,6 +37,9 @@ const getWipeUseriOSPodsCache = () => {
 };
 const getWipeAndroidBuild = () => {
   return wipeAndroidBuild;
+};
+const getWipeSystemGradleCache = () => {
+  return wipeSystemGradleCache;
 };
 const getWipeNodeModules = () => {
   return wipeNodeModules;
@@ -130,6 +134,21 @@ const askAndroidCleanProject = () =>
     });
   });
 
+const askWipeSystemGradleCache = () =>
+  new Promise((resolve) => {
+    if (args.includes('--keep-system-gradle-cache')) {
+      wipeSystemGradleCache = false;
+      return resolve();
+    }
+    return askQuestion('Clean system gradle cache? (Y/n) ', (answer) => {
+      wipeSystemGradleCache = checkAnswer(
+        answer,
+        askWipeSystemGradleCache,
+        resolve
+      );
+    });
+  });
+
 const askAndroid = () =>
   new Promise((resolve) => {
     if (args.includes('--remove-android-build')) {
@@ -181,6 +200,7 @@ module.exports = {
   getWipeSystemiOSPodsCache,
   getWipeUseriOSPodsCache,
   getWipeAndroidBuild,
+  getWipeSystemGradleCache,
   getWipeNodeModules,
   getUpdateBrew,
   getUpdatePods,
@@ -188,6 +208,7 @@ module.exports = {
   askiOSPods,
   askSystemiOSPodsCache,
   askUseriOSPodsCache,
+  askWipeSystemGradleCache,
   askUpdatePods,
   askAndroid,
   askAndroidCleanProject,

--- a/source/internals/tasks.js
+++ b/source/internals/tasks.js
@@ -35,6 +35,11 @@ const tasks = {
     command: '(cd android && ./gradlew clean)',
     args: []
   },
+  wipeSystemGradleCache: {
+    name: 'wipe system gradle cache',
+    command: 'rm',
+    args: ['-rf', '~/.gradle/caches']
+  },
   watchmanCacheClear: {
     name: 'watchman cache clear (if watchman is installed)',
     command: 'watchman watch-del-all || true',
@@ -95,6 +100,7 @@ const autoTasks = [
   tasks.watchmanCacheClear,
   tasks.wipeTempCaches,
   tasks.cleanAndroidProject,
+  tasks.wipeSystemGradleCache,
   tasks.wipeNodeModules,
   tasks.yarnCacheClean,
   tasks.npmCacheVerify,


### PR DESCRIPTION
The system gradle cache can corrupt Android builds, especially CMake. In this PR I've added wiping the system gradle cache as an option.